### PR TITLE
ScalaのバージョンをGenKanのものと統一

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u222_1.3.2_2.12.10
+FROM hseeberger/scala-sbt:8u252_1.3.10_2.12.11
 USER root
 
 ENV PGSSLMODE=disable\


### PR DESCRIPTION
ScalaのバージョンをGenKanのものと統一しました
ref : https://github.com/koska-devs/GenKan/blob/develop/genkan-server/Dockerfile#L1

お手すきの際に確認お願いしますmm